### PR TITLE
Add HRDEM downloader utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+HRDEM/
+*.vrt
+index_manifest.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # hauteresolution_dtm_mnt
-Downloads all available High-Resolution Digital Elevation Model (HRDEM) GeoTIFF tiles for the entire country of Canada from Natural Resources Canada’s FTP or HTTPS endpoint.
+
+This repository contains a small utility script for **mirroring** the HRDEM
+(High-Resolution Digital Elevation Model) tiles from the Natural Resources
+Canada open data site. The dataset is extremely large and cannot be shipped with
+this repository.
+
+## Usage
+
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the downloader (this will fetch many GBs of data):
+   ```bash
+   python download_hrdem.py
+   ```
+   The script recreates the remote directory structure inside the `HRDEM/`
+   folder, generates `index_manifest.json` with basic metadata for each tile and
+   builds `hrdem.vrt` for easy use in GIS software.
+
+The script relies on `requests`, `beautifulsoup4`, `rasterio` and `gdal`
+(`gdalbuildvrt` must be available in your PATH). Network issues or large data
+volumes may require additional configuration.

--- a/download_hrdem.py
+++ b/download_hrdem.py
@@ -1,0 +1,85 @@
+import os
+import json
+import requests
+from urllib.parse import urljoin
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://ftp.maps.canada.ca/pub/nrcan_rncan/elevation/canada/hrdem-lidar/indexed/"
+
+MANIFEST_FILE = "index_manifest.json"
+DATA_DIR = "HRDEM"
+VRT_FILE = "hrdem.vrt"
+
+
+def ensure_dir(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+
+def list_links(url):
+    """Return href links from an index page"""
+    r = requests.get(url)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    for a in soup.find_all("a"):
+        href = a.get("href")
+        if href and href not in ("../", "/"):
+            yield href
+
+
+def download_file(url, out_path):
+    print(f"Downloading {url} -> {out_path}")
+    ensure_dir(os.path.dirname(out_path))
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        with open(out_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+
+
+def traverse(base_url, local_dir, manifest):
+    for link in list_links(base_url):
+        if link.endswith('/'):
+            traverse(urljoin(base_url, link), os.path.join(local_dir, link), manifest)
+        elif link.lower().endswith('.tif'):
+            dest = os.path.join(local_dir, link)
+            url = urljoin(base_url, link)
+            download_file(url, dest)
+            meta = get_metadata(dest)
+            manifest.append(meta)
+
+
+def get_metadata(tif_path):
+    try:
+        import rasterio
+        with rasterio.open(tif_path) as src:
+            bounds = src.bounds
+            res = max(src.res)
+            crs = src.crs.to_string()
+    except Exception as e:
+        bounds = None
+        res = None
+        crs = None
+    return {
+        "file": tif_path,
+        "bounds": bounds and list(bounds),
+        "crs": crs,
+        "resolution": res,
+    }
+
+
+def write_manifest(manifest):
+    with open(MANIFEST_FILE, 'w') as f:
+        json.dump(manifest, f, indent=2)
+
+
+def build_vrt():
+    os.system(f"gdalbuildvrt -input_file_list <(find {DATA_DIR} -name '*.tif') {VRT_FILE}")
+
+
+if __name__ == "__main__":
+    manifest = []
+    traverse(BASE_URL, DATA_DIR, manifest)
+    write_manifest(manifest)
+    build_vrt()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+rasterio


### PR DESCRIPTION
## Summary
- implement `download_hrdem.py` for recursively mirroring HRDEM tiles
- describe usage and requirements in README
- add pip requirements list
- ignore generated data and artifacts

## Testing
- `python -m py_compile download_hrdem.py`
- `pip install -r requirements.txt` *(fails: ProxyError 403 when running the script)*

------
https://chatgpt.com/codex/tasks/task_e_68468e998324832a82e665610131b86f