### PR TITLE
Add initial Blender × ComfyUI Phase A add-on scaffolding

### DIFF
--- a/blender-comfyui/LICENSE
+++ b/blender-comfyui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Blender × ComfyUI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/blender-comfyui/README.md
+++ b/blender-comfyui/README.md
@@ -1,0 +1,54 @@
+# Blender × ComfyUI Bridge (Phase A)
+
+This repository contains a work-in-progress Blender add-on that helps artists interact with a local [ComfyUI](https://github.com/comfyanonymous/ComfyUI) instance without leaving Blender. The current focus is the Phase A milestone – starting/stopping ComfyUI, streaming its logs into Blender, and driving an external webview pointed at the ComfyUI frontend.
+
+## Features
+
+- Configure ComfyUI install & Python paths via add-on preferences.
+- Start/stop a local ComfyUI server directly from an N-panel in the 3D Viewport.
+- Stream ComfyUI stdout/stderr logs into Blender with a multi-line text box.
+- Ping the ComfyUI REST API to verify connectivity.
+- Launch/focus/close a pywebview-powered external window pointed at `http://<host>:<port>`.
+- Extensible module layout that prepares for the Phase B embedded Chromium workflow.
+
+## Requirements
+
+- Blender 4.0 or newer (Python 3.11 runtime).
+- A working ComfyUI checkout containing `main.py`.
+- Optional: [pywebview](https://pywebview.flowrl.com/) installed into Blender's Python environment for the Phase A webview controls.
+- Optional: `requests` Python package (Blender bundles it by default, but custom builds may not).
+
+## Installing the add-on
+
+1. Clone/download this repository.
+2. Zip the `blender-comfyui/addon` folder (e.g. `zip -r blender-comfyui.zip blender-comfyui/addon`).
+3. In Blender, open **Edit → Preferences… → Add-ons → Install…**, pick the generated zip, and enable the add-on.
+4. Open the add-on preferences to configure:
+   - **ComfyUI Folder**: the directory containing ComfyUI's `main.py`.
+   - **Python Executable** (optional): override interpreter path.
+   - **Host/Port**: defaults to `127.0.0.1:8188`.
+   - **Log History Lines**: number of lines preserved in the log buffer.
+   - **Always on Top**: whether the external webview stays above other windows.
+
+After configuring, open the **View3D → Sidebar → ComfyUI** panel. Use **Start ComfyUI** to launch the server and **Open ComfyUI Webview** to spawn the external window.
+
+## Troubleshooting
+
+- **pywebview missing**: Install it into Blender's bundled Python with `"<blender.exe>\python\bin\python.exe" -m pip install pywebview`.
+- **Python executable not found**: Set an explicit interpreter path in preferences.
+- **Logs not updating**: Ensure the add-on is enabled and ComfyUI is running; the log buffer refreshes twice a second.
+
+## Repository layout
+
+```
+blender-comfyui/
+  addon/               # Blender add-on modules
+  docs/                # Additional documentation & packaging notes
+  tests/manual-checklist.md
+```
+
+Phase B (embedded Chromium via CEF) scaffolding lives in `addon/cef_embed.py`, `addon/draw.py`, and `addon/events.py` but is not yet implemented.
+
+## License
+
+This project uses permissive dependencies only. See [`docs/license-notices.md`](docs/license-notices.md) for third-party acknowledgements. All custom code in this repository is MIT licensed.

--- a/blender-comfyui/addon/__init__.py
+++ b/blender-comfyui/addon/__init__.py
@@ -1,0 +1,73 @@
+"""Blender × ComfyUI add-on bootstrap package."""
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Iterable, List
+
+import bpy
+
+bl_info = {
+    "name": "Blender × ComfyUI Bridge",
+    "author": "OpenAI Assistant",
+    "version": (0, 1, 0),
+    "blender": (4, 0, 0),
+    "location": "View3D > Sidebar > ComfyUI",
+    "description": "Control a local ComfyUI server and surface its UI/logs inside Blender.",
+    "warning": "Proof-of-concept implementation of Phase A",
+    "doc_url": "https://github.com/",
+    "category": "System",
+}
+
+
+_MODULES: List[ModuleType] = []
+
+
+def _load_modules() -> Iterable[ModuleType]:
+    module_names = (
+        "prefs",
+        "manager",
+        "api_bridge",
+        "webview_external",
+        "ui_panel",
+        "cef_embed",
+        "draw",
+        "events",
+    )
+
+    loaded: List[ModuleType] = []
+    package = __name__
+    for name in module_names:
+        full_name = f"{package}.{name}"
+        module = importlib.import_module(full_name)
+        if module not in loaded:
+            loaded.append(module)
+    return loaded
+
+
+def register() -> None:
+    global _MODULES
+
+    modules = list(_load_modules())
+    for module in modules:
+        if hasattr(module, "register"):
+            module.register()
+    _MODULES = modules
+
+
+def unregister() -> None:
+    global _MODULES
+
+    for module in reversed(_MODULES):
+        if hasattr(module, "unregister"):
+            try:
+                module.unregister()
+            except Exception:  # pragma: no cover - defensive
+                import traceback
+
+                traceback.print_exc()
+    _MODULES.clear()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual debugging helper
+    register()

--- a/blender-comfyui/addon/api_bridge.py
+++ b/blender-comfyui/addon/api_bridge.py
@@ -1,0 +1,43 @@
+"""Minimal REST helpers for communicating with a ComfyUI server."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from .prefs import ComfyAddonPreferences
+
+DEFAULT_TIMEOUT = 5.0
+
+
+class ComfyApiError(RuntimeError):
+    """Raised when the ComfyUI API returned an unexpected response."""
+
+
+def _request_json(method: str, url: str, *, timeout: float, json_payload: Optional[Dict[str, Any]] = None) -> Any:
+    response = requests.request(method, url, json=json_payload, timeout=timeout)
+    response.raise_for_status()
+    if not response.content:
+        return None
+    return response.json()
+
+
+def system_stats(prefs: ComfyAddonPreferences, timeout: float = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    url = f"{prefs.base_url()}/system_stats"
+    data = _request_json("GET", url, timeout=timeout)
+    if not isinstance(data, dict):  # pragma: no cover - defensive
+        raise ComfyApiError("Unexpected response payload from /system_stats")
+    return data
+
+
+def ping(prefs: ComfyAddonPreferences, timeout: float = DEFAULT_TIMEOUT) -> bool:
+    try:
+        system_stats(prefs, timeout=timeout)
+    except (requests.RequestException, ComfyApiError):
+        return False
+    return True
+
+
+def send_prompt(prefs: ComfyAddonPreferences, workflow_json: Dict[str, Any], timeout: float = DEFAULT_TIMEOUT) -> Any:
+    url = f"{prefs.base_url()}/prompt"
+    return _request_json("POST", url, timeout=timeout, json_payload=workflow_json)

--- a/blender-comfyui/addon/cef_embed.py
+++ b/blender-comfyui/addon/cef_embed.py
@@ -1,0 +1,34 @@
+"""Placeholder module for Phase B (CEF embedding)."""
+from __future__ import annotations
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CefRuntime:
+    """Minimal stub describing the future CEF runtime integration."""
+
+    def __init__(self) -> None:
+        self.initialised = False
+
+    def initialize(self) -> None:
+        _LOGGER.info("CEF embedding is not yet implemented. Phase B will provide this feature.")
+
+    def shutdown(self) -> None:
+        _LOGGER.info("CEF embedding shutdown placeholder invoked.")
+
+
+_RUNTIME = CefRuntime()
+
+
+def get_runtime() -> CefRuntime:
+    return _RUNTIME
+
+
+def register() -> None:  # pragma: no cover - nothing to register yet
+    pass
+
+
+def unregister() -> None:
+    _RUNTIME.shutdown()

--- a/blender-comfyui/addon/draw.py
+++ b/blender-comfyui/addon/draw.py
@@ -1,0 +1,14 @@
+"""Rendering helpers placeholder for Phase B."""
+from __future__ import annotations
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def register() -> None:  # pragma: no cover - placeholder
+    _LOGGER.debug("draw module placeholder register() called")
+
+
+def unregister() -> None:  # pragma: no cover - placeholder
+    _LOGGER.debug("draw module placeholder unregister() called")

--- a/blender-comfyui/addon/events.py
+++ b/blender-comfyui/addon/events.py
@@ -1,0 +1,14 @@
+"""Input event translation placeholder for Phase B."""
+from __future__ import annotations
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def register() -> None:  # pragma: no cover - placeholder
+    _LOGGER.debug("events module placeholder register() called")
+
+
+def unregister() -> None:  # pragma: no cover - placeholder
+    _LOGGER.debug("events module placeholder unregister() called")

--- a/blender-comfyui/addon/manager.py
+++ b/blender-comfyui/addon/manager.py
@@ -1,0 +1,204 @@
+"""Process management and logging helpers for the ComfyUI bridge."""
+from __future__ import annotations
+
+import queue
+import subprocess
+import threading
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Deque, Optional
+
+import bpy
+from bpy.app.timers import TimerError
+from bpy.props import BoolProperty, StringProperty
+
+from .prefs import ComfyAddonPreferences, get_preferences
+
+LOG_TIMER_INTERVAL = 0.5
+STOP_TIMEOUT = 5.0
+
+
+@dataclass
+class LogSnapshot:
+    text: str
+    line_count: int
+
+
+class ComfyProcessManager:
+    """Manage a ComfyUI subprocess and surface its log output."""
+
+    def __init__(self) -> None:
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._log_queue: "queue.Queue[str]" = queue.Queue()
+        self._log_cache: Deque[str] = deque(maxlen=500)
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._timer_registered: bool = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def start(self, prefs: ComfyAddonPreferences) -> None:
+        if self.is_running:
+            return
+
+        validation = prefs.validate()
+        if not validation.ok:
+            raise RuntimeError(validation.message)
+
+        python = prefs.resolved_python() or self._auto_python_path()
+        if python is None:
+            raise RuntimeError("Unable to locate Python executable. Set one in the add-on preferences.")
+
+        comfy_dir = prefs.comfy_path()
+        command = [python, "main.py", "--listen", prefs.host, "--port", str(prefs.port)]
+
+        try:
+            self._process = subprocess.Popen(
+                command,
+                cwd=str(comfy_dir),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                universal_newlines=True,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"Failed to launch ComfyUI: {exc}") from exc
+
+        self._stop_event.clear()
+        self._log_cache = deque(maxlen=prefs.log_history_lines)
+        self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader_thread.start()
+
+        self._set_running_state(True)
+        self._ensure_timer()
+
+    def stop(self) -> None:
+        if not self.is_running:
+            return
+
+        assert self._process is not None
+        process = self._process
+        self._stop_event.set()
+
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=STOP_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+        if process.stdout is not None:
+            process.stdout.close()
+        self._process = None
+        self._reader_thread = None
+        self._set_running_state(False)
+        self._cancel_timer()
+        self._flush_logs()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    # ------------------------------------------------------------------
+    # Log access
+    # ------------------------------------------------------------------
+    def snapshot(self) -> LogSnapshot:
+        lines = list(self._log_cache)
+        return LogSnapshot("\n".join(lines), len(lines))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _auto_python_path(self) -> Optional[str]:
+        return str(Path(bpy.app.binary_path_python)) if bpy.app.binary_path_python else None
+
+    def _reader_loop(self) -> None:
+        assert self._process is not None
+        if self._process.stdout is None:
+            return
+
+        for raw_line in self._process.stdout:
+            if self._stop_event.is_set():
+                break
+            line = raw_line.rstrip("\n")
+            self._log_queue.put(line)
+
+        # Drain remaining data
+        remaining = self._process.stdout.read()
+        if remaining:
+            for raw_line in remaining.splitlines():
+                self._log_queue.put(raw_line)
+
+    def _ensure_timer(self) -> None:
+        if self._timer_registered:
+            return
+        bpy.app.timers.register(self._flush_logs_timer, first_interval=LOG_TIMER_INTERVAL)
+        self._timer_registered = True
+
+    def _cancel_timer(self) -> None:
+        if not self._timer_registered:
+            return
+        try:
+            bpy.app.timers.unregister(self._flush_logs_timer)
+        except TimerError:
+            pass
+        finally:
+            self._timer_registered = False
+
+    def _flush_logs_timer(self) -> float:
+        self._flush_logs()
+        return LOG_TIMER_INTERVAL if self.is_running else -1.0
+
+    def _flush_logs(self) -> None:
+        prefs = get_preferences()
+        target_size = prefs.log_history_lines
+        if self._log_cache.maxlen != target_size:
+            self._log_cache = deque(self._log_cache, maxlen=target_size)
+
+        changed = False
+        while True:
+            try:
+                line = self._log_queue.get_nowait()
+            except queue.Empty:
+                break
+            self._log_cache.append(line)
+            changed = True
+
+        if changed:
+            wm = bpy.context.window_manager
+            if hasattr(wm, "blender_comfyui_log"):
+                wm.blender_comfyui_log = "\n".join(self._log_cache)
+
+    def _set_running_state(self, running: bool) -> None:
+        wm = bpy.context.window_manager
+        if hasattr(wm, "blender_comfyui_server_running"):
+            wm.blender_comfyui_server_running = running
+
+
+_MANAGER = ComfyProcessManager()
+
+
+def get_manager() -> ComfyProcessManager:
+    return _MANAGER
+
+
+def register() -> None:
+    bpy.types.WindowManager.blender_comfyui_log = StringProperty(
+        name="ComfyUI Log", default="", options={"MULTILINE"}
+    )
+    bpy.types.WindowManager.blender_comfyui_server_running = BoolProperty(
+        name="ComfyUI Running", default=False
+    )
+
+
+def unregister() -> None:
+    _MANAGER.stop()
+    _MANAGER._cancel_timer()
+    del bpy.types.WindowManager.blender_comfyui_log
+    del bpy.types.WindowManager.blender_comfyui_server_running

--- a/blender-comfyui/addon/prefs.py
+++ b/blender-comfyui/addon/prefs.py
@@ -1,0 +1,136 @@
+"""Add-on preferences for the Blender × ComfyUI bridge."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import bpy
+from bpy.props import BoolProperty, FloatVectorProperty, IntProperty, StringProperty
+from bpy.types import AddonPreferences, Context
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    message: str = ""
+
+
+class ComfyAddonPreferences(AddonPreferences):
+    """Preferences exposed under the add-on section in Blender."""
+
+    bl_idname = __package__ or "blender-comfyui.addon"
+
+    comfy_dir: StringProperty(  # type: ignore[assignment]
+        name="ComfyUI Folder",
+        description="Path to the ComfyUI repository containing main.py",
+        subtype="DIR_PATH",
+        default="",
+    )
+    python_exe: StringProperty(  # type: ignore[assignment]
+        name="Python Executable",
+        description="Optional override for the Python interpreter used to launch ComfyUI",
+        subtype="FILE_PATH",
+        default="",
+    )
+    host: StringProperty(  # type: ignore[assignment]
+        name="Host",
+        default="127.0.0.1",
+        description="ComfyUI host to bind and connect to",
+    )
+    port: IntProperty(  # type: ignore[assignment]
+        name="Port",
+        default=8188,
+        min=1,
+        max=65535,
+        description="ComfyUI port to bind and connect to",
+    )
+    log_history_lines: IntProperty(  # type: ignore[assignment]
+        name="Log History Lines",
+        default=500,
+        min=50,
+        max=5000,
+        description="Maximum number of log lines kept in the in-Blender log buffer.",
+    )
+    webview_bounds: FloatVectorProperty(  # type: ignore[assignment]
+        name="Webview Bounds",
+        description="Stored window bounds for the external ComfyUI view (x, y, width, height)",
+        subtype="NONE",
+        size=4,
+        default=(100.0, 100.0, 1280.0, 720.0),
+    )
+    always_on_top: BoolProperty(  # type: ignore[assignment]
+        name="Always on Top",
+        description="Keep the external ComfyUI webview floating on top of other windows",
+        default=True,
+    )
+
+    def draw(self, context: Context) -> None:
+        layout = self.layout
+        layout.prop(self, "comfy_dir")
+        layout.prop(self, "python_exe")
+        layout.separator()
+        layout.prop(self, "host")
+        layout.prop(self, "port")
+        layout.separator()
+        layout.prop(self, "log_history_lines")
+        layout.prop(self, "always_on_top")
+
+        result = self.validate()
+        box = layout.box()
+        icon = "CHECKMARK" if result.ok else "ERROR"
+        box.label(text="Validation: " + (result.message or "OK"), icon=icon)
+
+    def validate(self) -> ValidationResult:
+        """Validate the configuration and provide a user-friendly message."""
+
+        comfy_dir_path = Path(self.comfy_dir).expanduser()
+        if not comfy_dir_path.exists():
+            return ValidationResult(False, "ComfyUI folder does not exist")
+        if not comfy_dir_path.is_dir():
+            return ValidationResult(False, "ComfyUI path is not a directory")
+        main_py = comfy_dir_path / "main.py"
+        if not main_py.exists():
+            return ValidationResult(False, "ComfyUI main.py was not found in the selected folder")
+
+        if self.python_exe:
+            python_path = Path(self.python_exe).expanduser()
+            if not python_path.exists():
+                return ValidationResult(False, "Python executable override does not exist")
+            if not python_path.is_file():
+                return ValidationResult(False, "Python executable override is not a file")
+
+        return ValidationResult(True, "Configuration looks good")
+
+    def resolved_python(self) -> Optional[str]:
+        """Return the preferred Python executable path or ``None`` if auto-detect should be used."""
+
+        python_override = self.python_exe.strip()
+        if python_override:
+            return str(Path(python_override).expanduser())
+        return None
+
+    def comfy_path(self) -> Path:
+        return Path(self.comfy_dir).expanduser()
+
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+
+def get_preferences(context: Optional[Context] = None) -> ComfyAddonPreferences:
+    """Utility to access the add-on preferences from anywhere."""
+
+    context = context or bpy.context
+    addon_name = __package__.rsplit(".", 1)[0] if __package__ else "blender-comfyui.addon"
+    prefs = context.preferences.addons.get(addon_name)
+    if prefs is None:
+        raise RuntimeError("Blender × ComfyUI add-on is not registered")
+    return prefs.preferences  # type: ignore[return-value]
+
+
+def register() -> None:
+    bpy.utils.register_class(ComfyAddonPreferences)
+
+
+def unregister() -> None:
+    bpy.utils.unregister_class(ComfyAddonPreferences)

--- a/blender-comfyui/addon/ui_panel.py
+++ b/blender-comfyui/addon/ui_panel.py
@@ -1,0 +1,173 @@
+"""UI elements and operators for the Blender × ComfyUI bridge."""
+from __future__ import annotations
+
+import bpy
+from bpy.types import Operator, Panel
+
+from . import api_bridge
+from .manager import get_manager
+from .prefs import get_preferences
+from .webview_external import WindowBounds, get_controller
+
+
+class BLENDCOMFY_OT_start_server(Operator):
+    bl_idname = "blendcomfy.start_server"
+    bl_label = "Start ComfyUI"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        prefs = get_preferences(context)
+        manager = get_manager()
+        if manager.is_running:
+            self.report({"INFO"}, "ComfyUI server already running")
+            return {"CANCELLED"}
+        try:
+            manager.start(prefs)
+        except Exception as exc:
+            self.report({"ERROR"}, str(exc))
+            return {"CANCELLED"}
+
+        self.report({"INFO"}, "ComfyUI server starting…")
+        return {"FINISHED"}
+
+
+class BLENDCOMFY_OT_stop_server(Operator):
+    bl_idname = "blendcomfy.stop_server"
+    bl_label = "Stop ComfyUI"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        manager = get_manager()
+        if not manager.is_running:
+            self.report({"INFO"}, "ComfyUI server is not running")
+            return {"CANCELLED"}
+        manager.stop()
+        self.report({"INFO"}, "ComfyUI server stopped")
+        return {"FINISHED"}
+
+
+class BLENDCOMFY_OT_ping_server(Operator):
+    bl_idname = "blendcomfy.ping_server"
+    bl_label = "Ping API"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        prefs = get_preferences(context)
+        ok = api_bridge.ping(prefs)
+        if ok:
+            self.report({"INFO"}, "ComfyUI API reachable")
+            return {"FINISHED"}
+        self.report({"ERROR"}, "Failed to reach ComfyUI API")
+        return {"CANCELLED"}
+
+
+class BLENDCOMFY_OT_open_webview(Operator):
+    bl_idname = "blendcomfy.open_webview"
+    bl_label = "Open ComfyUI Webview"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        prefs = get_preferences(context)
+        controller = get_controller()
+        bounds = WindowBounds(*prefs.webview_bounds)
+        try:
+            controller.open(prefs.base_url(), always_on_top=prefs.always_on_top, bounds=bounds)
+        except Exception as exc:
+            self.report({"ERROR"}, str(exc))
+            return {"CANCELLED"}
+        self.report({"INFO"}, "Opened ComfyUI webview")
+        return {"FINISHED"}
+
+
+class BLENDCOMFY_OT_close_webview(Operator):
+    bl_idname = "blendcomfy.close_webview"
+    bl_label = "Close ComfyUI Webview"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        controller = get_controller()
+        if not controller.is_open():
+            self.report({"INFO"}, "ComfyUI webview is not open")
+            return {"CANCELLED"}
+        controller.close()
+        self.report({"INFO"}, "Closed ComfyUI webview")
+        return {"FINISHED"}
+
+
+class BLENDCOMFY_OT_focus_webview(Operator):
+    bl_idname = "blendcomfy.focus_webview"
+    bl_label = "Focus ComfyUI Webview"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        controller = get_controller()
+        if not controller.is_open():
+            self.report({"INFO"}, "ComfyUI webview is not open")
+            return {"CANCELLED"}
+        controller.focus()
+        self.report({"INFO"}, "Focused ComfyUI webview")
+        return {"FINISHED"}
+
+
+class BLENDCOMFY_PT_sidebar(Panel):
+    bl_idname = "BLENDCOMFY_PT_sidebar"
+    bl_label = "ComfyUI"
+    bl_category = "ComfyUI"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+
+    def draw(self, context: bpy.types.Context) -> None:
+        layout = self.layout
+        wm = context.window_manager
+        prefs = get_preferences(context)
+        controller = get_controller()
+
+        row = layout.row()
+        row.prop(wm, "blender_comfyui_server_running", text="Server Running", toggle=True)
+
+        row = layout.row()
+        row.enabled = not wm.blender_comfyui_server_running
+        row.operator(BLENDCOMFY_OT_start_server.bl_idname, icon="PLAY")
+
+        row = layout.row()
+        row.enabled = wm.blender_comfyui_server_running
+        row.operator(BLENDCOMFY_OT_stop_server.bl_idname, icon="STOP")
+
+        row = layout.row(align=True)
+        row.operator(BLENDCOMFY_OT_ping_server.bl_idname, icon="URL")
+        row.operator(BLENDCOMFY_OT_open_webview.bl_idname, icon="FILE_FOLDER")
+        sub = row.row(align=True)
+        sub.enabled = controller.is_open()
+        sub.operator(BLENDCOMFY_OT_focus_webview.bl_idname, icon="VIEWZOOM")
+        sub.operator(BLENDCOMFY_OT_close_webview.bl_idname, icon="PANEL_CLOSE")
+
+        layout.separator()
+        layout.label(text="Logs (latest {} lines):".format(prefs.log_history_lines))
+        col = layout.column()
+        col.prop(wm, "blender_comfyui_log", text="", slider=False)
+
+        layout.separator()
+        validation = prefs.validate()
+        icon = "CHECKMARK" if validation.ok else "ERROR"
+        layout.label(text=f"Preferences: {validation.message}", icon=icon)
+
+
+_CLASSES = (
+    BLENDCOMFY_OT_start_server,
+    BLENDCOMFY_OT_stop_server,
+    BLENDCOMFY_OT_ping_server,
+    BLENDCOMFY_OT_open_webview,
+    BLENDCOMFY_OT_close_webview,
+    BLENDCOMFY_OT_focus_webview,
+    BLENDCOMFY_PT_sidebar,
+)
+
+
+def register() -> None:
+    for cls in _CLASSES:
+        bpy.utils.register_class(cls)
+
+
+def unregister() -> None:
+    for cls in reversed(_CLASSES):
+        bpy.utils.unregister_class(cls)

--- a/blender-comfyui/addon/webview_external.py
+++ b/blender-comfyui/addon/webview_external.py
@@ -1,0 +1,126 @@
+"""External webview management for the ComfyUI UI (Phase A)."""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import webview
+except Exception:  # pragma: no cover - optional dependency
+    webview = None  # type: ignore[assignment]
+
+
+@dataclass
+class WindowBounds:
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class ExternalWebviewController:
+    """Manage a pywebview window pointing to the ComfyUI frontend."""
+
+    def __init__(self) -> None:
+        self._window: Optional["webview.Window"] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._target_url: Optional[str] = None
+        self._always_on_top: bool = True
+        self._bounds = WindowBounds(100, 100, 1280, 720)
+
+    # ------------------------------------------------------------------
+    def open(self, url: str, *, always_on_top: bool, bounds: WindowBounds) -> None:
+        if webview is None:
+            raise RuntimeError("pywebview is not available. Install it in Blender's Python environment.")
+
+        with self._lock:
+            self._target_url = url
+            self._always_on_top = always_on_top
+            self._bounds = bounds
+
+            if self._window is not None and self._thread and self._thread.is_alive():
+                self._window.load_url(url)
+                self._apply_window_state()
+                return
+
+            def _run() -> None:
+                window = webview.create_window(
+                    "ComfyUI",
+                    url,
+                    x=int(bounds.x),
+                    y=int(bounds.y),
+                    width=int(bounds.width),
+                    height=int(bounds.height),
+                    on_top=always_on_top,
+                )
+                self._window = window
+                try:
+                    webview.start(self._on_ready, window)
+                finally:
+                    with self._lock:
+                        self._window = None
+                        self._thread = None
+
+            thread = threading.Thread(target=_run, daemon=True)
+            self._thread = thread
+            thread.start()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._window is not None and webview is not None:
+                webview.destroy_window(self._window)
+            self._window = None
+            self._thread = None
+
+    def focus(self) -> None:
+        with self._lock:
+            if self._window is not None:
+                try:
+                    self._window.bring_to_front()
+                except AttributeError:  # pragma: no cover - platform dependent
+                    pass
+
+    def set_bounds(self, bounds: WindowBounds) -> None:
+        with self._lock:
+            self._bounds = bounds
+            if self._window is not None:
+                try:
+                    self._window.resize(int(bounds.width), int(bounds.height))
+                    self._window.move(int(bounds.x), int(bounds.y))
+                except AttributeError:  # pragma: no cover - platform dependent
+                    pass
+
+    def is_open(self) -> bool:
+        with self._lock:
+            if self._window is None:
+                return False
+            return bool(webview and self._window in webview.windows)
+
+    # ------------------------------------------------------------------
+    def _apply_window_state(self) -> None:
+        if self._window is None:
+            return
+        try:
+            self._window.on_top = self._always_on_top
+        except AttributeError:  # pragma: no cover - platform dependent
+            pass
+
+    def _on_ready(self) -> None:
+        self._apply_window_state()
+
+
+_CONTROLLER = ExternalWebviewController()
+
+
+def get_controller() -> ExternalWebviewController:
+    return _CONTROLLER
+
+
+def register() -> None:  # pragma: no cover - nothing to do
+    pass
+
+
+def unregister() -> None:
+    _CONTROLLER.close()

--- a/blender-comfyui/docs/build-matrix.md
+++ b/blender-comfyui/docs/build-matrix.md
@@ -1,0 +1,16 @@
+# Build Matrix & Dependency Notes
+
+The add-on targets Blender 4.x which bundles Python 3.11 on all desktop platforms. The following table captures the expected compatibility targets for both the Phase A (pywebview) and Phase B (CEF) milestones.
+
+| Platform | Blender Version | Python ABI | Phase A Dependencies | Phase B Dependencies |
+|----------|-----------------|------------|-----------------------|----------------------|
+| Windows 11 (x64) | 4.0 – 4.2 | CPython 3.11 | `pywebview>=4.4`, `requests` | `cefpython3` wheel built for Python 3.11, `numpy` (transitive) |
+| Linux (Ubuntu 22.04+) | 4.0 – 4.2 | CPython 3.11 | `pywebview>=4.4` (GTK backend) | `cefpython3` manylinux wheel (pending) |
+| macOS 14 (Apple Silicon) | 4.0 – 4.2 | CPython 3.11 | `pywebview>=4.4` (Cocoa backend) | `cefpython3` universal2 build (pending upstream) |
+
+Notes:
+
+- Blender for Windows ships with an embedded Python interpreter located at `blender.exe\..\python\bin\python.exe`. The add-on can bootstrap packages via `pip` using this interpreter.
+- `pywebview` offers multiple GUI backends. For Windows we recommend the default MSHTML/Edge backend. Linux requires GTK packages installed system-wide.
+- `cefpython3` packages are large. The Phase B work will either vendor pre-built wheels (recommended for Windows) or download them on first run.
+- Keep an eye on GPU driver compatibility: CEF's accelerated compositing requires up-to-date drivers on NVIDIA/AMD cards.

--- a/blender-comfyui/docs/license-notices.md
+++ b/blender-comfyui/docs/license-notices.md
@@ -1,0 +1,15 @@
+# License Notices
+
+This project intends to stay compliant with all bundled/open-source components. The add-on source code in this repository is released under the MIT License.
+
+## Bundled / Referenced Dependencies
+
+| Component | License | Notes |
+|-----------|---------|-------|
+| Blender (runtime) | GPLv3 | User-supplied application; not redistributed here. |
+| ComfyUI | GPLv3 | User-supplied; the add-on interacts with an existing install. |
+| requests | Apache-2.0 | Bundled with Blender; used for REST calls. |
+| pywebview | BSD-3-Clause | Optional dependency for Phase A external window. |
+| cefpython3 | BSD-3-Clause | Planned Phase B dependency. |
+
+Include the corresponding LICENSE files when packaging third-party code (e.g., `cefpython3`).

--- a/blender-comfyui/docs/packaging.md
+++ b/blender-comfyui/docs/packaging.md
@@ -1,0 +1,25 @@
+# Packaging & Distribution
+
+## Phase A (External Webview)
+
+1. Ensure `pywebview` and `requests` are available in Blender's Python runtime.
+2. Zip the `addon/` directory: `cd blender-comfyui && zip -r blender-comfyui-phase-a.zip addon`.
+3. Test the archive inside a clean Blender profile by installing the zip through the Add-ons preferences window.
+4. Document any additional runtime requirements (GTK, MS Edge WebView2, etc.) per platform.
+
+## Phase B (Embedded Chromium)
+
+1. Download or vendor a matching `cefpython3` wheel for the target platform/ABI.
+2. Place the extracted package under `addon/vendor/cefpython3`. Keep the upstream `LICENSE` file intact.
+3. Update the add-on to bootstrap/prompt users to download missing binaries.
+4. Verify the add-on shuts down CEF cleanly when disabled or when Blender closes.
+
+## Versioning
+
+- Follow semantic versioning `(major, minor, patch)` as exposed through `bl_info['version']`.
+- Increment the minor version when adding visible functionality (e.g., Phase B embed).
+- Tag releases in source control and attach the packaged zip(s) to GitHub releases.
+
+## Testing Checklist
+
+See [`../tests/manual-checklist.md`](../tests/manual-checklist.md) for manual validation steps across Windows, Linux, and macOS.

--- a/blender-comfyui/tests/manual-checklist.md
+++ b/blender-comfyui/tests/manual-checklist.md
@@ -1,0 +1,32 @@
+# Manual Testing Checklist
+
+Use this checklist to validate Phase A functionality on each supported platform.
+
+## Environment Prep
+
+- [ ] Install Blender 4.0+ and enable the Blender × ComfyUI add-on.
+- [ ] Configure the add-on preferences with a valid ComfyUI folder.
+- [ ] Confirm `pywebview` is installed in Blender's Python runtime (`Help → Python Console`, `import webview`).
+
+## ComfyUI Lifecycle
+
+- [ ] Press **Start ComfyUI**. Verify the status toggle flips to *Server Running*.
+- [ ] Observe logs updating in real time. Confirm there are no UI freezes while ComfyUI boots.
+- [ ] Press **Ping API**. Expect a success toast once ComfyUI is ready.
+- [ ] Press **Stop ComfyUI**. Ensure the process terminates quickly and logs stop updating.
+- [ ] Repeat the start/stop cycle at least five times.
+
+## External Webview
+
+- [ ] Press **Open ComfyUI Webview**. A window should appear at the configured bounds displaying the ComfyUI UI.
+- [ ] Toggle focus using the **Focus Webview** operator.
+- [ ] Resize/reposition the window manually, then close it via **Close Webview**.
+- [ ] Restart ComfyUI and open the webview again to ensure stability across restarts.
+
+## Error Handling
+
+- [ ] Start the server with an invalid Python executable path and confirm an error is reported.
+- [ ] Start the server with an invalid ComfyUI folder and confirm validation prevents launch.
+- [ ] Stop Blender while ComfyUI is running and ensure the subprocess terminates.
+
+Document any regressions or platform-specific quirks discovered during testing.


### PR DESCRIPTION
## Summary
- add a modular Blender add-on that wires preferences, process management, API helpers, and an external pywebview controller for ComfyUI
- surface start/stop, ping, and log viewing controls in a new View3D sidebar panel
- document installation, packaging, license notices, and manual testing expectations for Phase A

## Testing
- not run (Blender-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68d68acd0ffc832aa0421cd5282231b2